### PR TITLE
fix(oidc): grant infra deploy role IAM managed policy permissions

### DIFF
--- a/terraform/environmental/oidc.tf
+++ b/terraform/environmental/oidc.tf
@@ -323,6 +323,21 @@ resource "aws_iam_role_policy" "github_actions_infra_deploy" {
           }
         }
       },
+      {
+        Sid    = "IAMManagedPolicies"
+        Effect = "Allow"
+        Action = [
+          "iam:GetPolicy",
+          "iam:GetPolicyVersion",
+          "iam:CreatePolicy",
+          "iam:CreatePolicyVersion",
+          "iam:DeletePolicy",
+          "iam:DeletePolicyVersion",
+          "iam:ListPolicyVersions",
+          "iam:TagPolicy"
+        ]
+        Resource = "arn:aws:iam::${var.account_id}:policy/francescoalbanese-*"
+      },
     ]
   })
 }


### PR DESCRIPTION
## Summary

- The infra CI deploy role was missing IAM managed policy permissions (`GetPolicy`, `GetPolicyVersion`, `CreatePolicy`, `CreatePolicyVersion`, `DeletePolicy`, `DeletePolicyVersion`, `ListPolicyVersions`, `TagPolicy`)
- This caused `terraform apply` to fail when reading or managing the permissions boundary policy
- Permissions are scoped to `arn:aws:iam::*:policy/francescoalbanese-*` to follow least-privilege

## Test plan

- [ ] Verify CI `terraform plan` passes on this branch
- [ ] Verify `terraform apply` succeeds without IAM permission errors on the deploy role

🤖 Generated with [Claude Code](https://claude.com/claude-code)