### PR TITLE
fix(iam): tighten wildcard ARNs in OIDC/IAM policies

### DIFF
--- a/terraform/environmental/main.tf
+++ b/terraform/environmental/main.tf
@@ -1,5 +1,7 @@
 locals {
-  project_prefix = "francescoalbanese-dev"
+  project_prefix   = "francescoalbanese-dev"
+  site_bucket_name = "${local.project_prefix}-site-${var.account_id}"
+  site_bucket_arn  = "arn:aws:s3:::${local.site_bucket_name}"
 }
 
 # Route53 hosted zone for francescoalbanese.dev (in shared-services, centralised DNS)

--- a/terraform/environmental/oidc.tf
+++ b/terraform/environmental/oidc.tf
@@ -124,8 +124,8 @@ resource "aws_iam_policy" "infra_deploy_boundary" {
           "s3:GetBucketLocation"
         ]
         Resource = [
-          "arn:aws:s3:::francescoalbanese-*",
-          "arn:aws:s3:::francescoalbanese-*/*"
+          local.site_bucket_arn,
+          "${local.site_bucket_arn}/*"
         ]
       },
       {
@@ -138,14 +138,6 @@ resource "aws_iam_policy" "infra_deploy_boundary" {
             "aws:ResourceTag/franco:terraform_stack" = "francescoalbanese-dev-infra"
           }
         }
-      },
-      {
-        Sid    = "AllowSTSAssumeRole"
-        Effect = "Allow"
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Resource = [
-          "arn:aws:iam::${var.account_id}:role/francescoalbanese-*"
-        ]
       }
     ]
   })
@@ -196,7 +188,7 @@ resource "aws_iam_role_policy" "github_actions_infra_deploy" {
           "s3:ListBucket",
           "s3:PutBucketVersioning"
         ]
-        Resource = "arn:aws:s3:::francescoalbanese-*"
+        Resource = local.site_bucket_arn
       },
       {
         Sid    = "CloudFrontReadOnly"
@@ -308,15 +300,19 @@ resource "aws_iam_role_policy" "github_actions_infra_deploy" {
           "iam:ListOpenIDConnectProviders"
         ]
         Resource = [
-          "arn:aws:iam::${var.account_id}:role/francescoalbanese-*",
+          "arn:aws:iam::${var.account_id}:role/${local.project_prefix}-github-actions-deploy",
+          "arn:aws:iam::${var.account_id}:role/${local.project_prefix}-infra-github-actions-deploy",
           "arn:aws:iam::${var.account_id}:oidc-provider/token.actions.githubusercontent.com"
         ]
       },
       {
-        Sid      = "IAMCreateRoleWithBoundary"
-        Effect   = "Allow"
-        Action   = "iam:CreateRole"
-        Resource = "arn:aws:iam::${var.account_id}:role/francescoalbanese-*"
+        Sid    = "IAMCreateRoleWithBoundary"
+        Effect = "Allow"
+        Action = "iam:CreateRole"
+        Resource = [
+          "arn:aws:iam::${var.account_id}:role/${local.project_prefix}-github-actions-deploy",
+          "arn:aws:iam::${var.account_id}:role/${local.project_prefix}-infra-github-actions-deploy"
+        ]
         Condition = {
           StringEquals = {
             "iam:PermissionsBoundary" = aws_iam_policy.infra_deploy_boundary.arn
@@ -336,7 +332,7 @@ resource "aws_iam_role_policy" "github_actions_infra_deploy" {
           "iam:ListPolicyVersions",
           "iam:TagPolicy"
         ]
-        Resource = "arn:aws:iam::${var.account_id}:policy/francescoalbanese-*"
+        Resource = "arn:aws:iam::${var.account_id}:policy/${local.project_prefix}-infra-deploy-boundary"
       },
     ]
   })

--- a/terraform/environmental/s3.tf
+++ b/terraform/environmental/s3.tf
@@ -1,6 +1,6 @@
 # S3 bucket for static site hosting (private, accessed via CloudFront OAC)
 resource "aws_s3_bucket" "site" {
-  bucket = "${local.project_prefix}-site-${var.account_id}"
+  bucket = local.site_bucket_name
 
   tags = {
     Name = "${local.project_prefix}-site"


### PR DESCRIPTION
## Summary
- Replaced `francescoalbanese-*` S3 and IAM wildcard ARNs with exact bucket/role/policy ARNs across OIDC and IAM policies
- Removed unnecessary `sts:AssumeRoleWithWebIdentity` statement from permissions boundary (no child role requires it)
- DRYed bucket name/ARN into `locals` block in `main.tf` to avoid duplication

## Test plan
- [ ] `terraform plan` in sandbox — no unexpected resource replacements
- [ ] GitHub Actions infra deploy workflow succeeds after merge
- [ ] Verify boundary still blocks creation of roles outside explicit ARN list

🤖 Generated with [Claude Code](https://claude.com/claude-code)