### PR TITLE
fix: remove CSP from CloudFront response headers policy

### DIFF
--- a/terraform/environmental/cloudfront.tf
+++ b/terraform/environmental/cloudfront.tf
@@ -51,10 +51,9 @@ resource "aws_cloudfront_response_headers_policy" "security_headers" {
       override     = true
     }
 
-    content_security_policy {
-      content_security_policy = "default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self'"
-      override                = true
-    }
+    # CSP moved to <meta> tag in HTML — Astro inlines scripts/styles that need
+    # per-build SHA-256 hashes, which can't be hardcoded here. See app repo
+    # docs/adr/001-csp-hash-strategy.md for rationale.
 
     referrer_policy {
       referrer_policy = "strict-origin-when-cross-origin"


### PR DESCRIPTION
## Summary
- Removes Content-Security-Policy from CloudFront response headers policy
- Astro inline scripts require per-build SHA-256 hashes that cannot be hardcoded in Terraform
- CSP now lives as a meta tag in the HTML, generated at build time with correct hashes

## Test plan
- Deploy infra and verify CloudFront no longer sets CSP response header
- Verify site loads correctly with CSP enforced via HTML meta tag
- Check browser console for any CSP violations after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)