### PR TITLE
feat(dns): add DMARC TXT record

### DIFF
--- a/terraform/environmental/dns.tf
+++ b/terraform/environmental/dns.tf
@@ -23,3 +23,15 @@ resource "aws_route53_record" "email_spf" {
     "v=spf1 include:_spf.porkbun.com ~all",
   ]
 }
+
+resource "aws_route53_record" "email_dmarc" {
+  provider = aws.shared_services
+  zone_id  = data.aws_route53_zone.main.zone_id
+  name     = "_dmarc.${var.domain_name}"
+  type     = "TXT"
+  ttl      = 300
+
+  records = [
+    "v=DMARC1; p=none; rua=mailto:hello@francescoalbanese.dev",
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `_dmarc.francescoalbanese.dev` TXT record to Route53
- Policy set to `p=none` (monitoring mode, no enforcement)
- Aggregate reports sent to `rua=mailto:hello@francescoalbanese.dev`
- Improves email deliverability and enables DMARC visibility

## Test plan
- [ ] `terraform plan` shows 1 resource to add (`aws_route53_record.email_dmarc`)
- [ ] After apply, DNS resolves: `dig TXT _dmarc.francescoalbanese.dev`
- [ ] DMARC record returns `v=DMARC1; p=none; rua=mailto:hello@francescoalbanese.dev`
- [ ] Aggregate reports received at `hello@francescoalbanese.dev` after sending test emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)