### PR TITLE
fix(ci): terraform apply always skipped due to wrapper exit code

### DIFF
--- a/.github/actions/configure-aws-env/action.yml
+++ b/.github/actions/configure-aws-env/action.yml
@@ -27,3 +27,4 @@ runs:
       uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: ${{ inputs.terraform-version }}
+        terraform_wrapper: false


### PR DESCRIPTION
## Summary
- Fix `terraform_wrapper: false` in `configure-aws-env` action — wrapper was swallowing exit code 2 from `-detailed-exitcode`, causing CI to treat planned changes as no-op and skip apply
- Add DMARC TXT record (`p=none` monitoring mode) for email deliverability on `francescoalbanese.dev`

## Test plan
- [ ] Trigger a CI run with infra changes — confirm terraform apply runs when plan has changes
- [ ] Verify DMARC record resolves: `dig TXT _dmarc.francescoalbanese.dev`
- [ ] Confirm no regression on runs with no infra changes (apply still skipped correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)