### PR TITLE
fix(iam): separate CloudFront Function actions from tag-condition statement

### DIFF
--- a/terraform/environmental/oidc.tf
+++ b/terraform/environmental/oidc.tf
@@ -218,10 +218,6 @@ resource "aws_iam_role_policy" "github_actions_infra_deploy" {
           "cloudfront:CreateOriginAccessControl",
           "cloudfront:UpdateOriginAccessControl",
           "cloudfront:DeleteOriginAccessControl",
-          "cloudfront:CreateFunction",
-          "cloudfront:UpdateFunction",
-          "cloudfront:DeleteFunction",
-          "cloudfront:PublishFunction",
           "cloudfront:CreateCachePolicy",
           "cloudfront:UpdateCachePolicy",
           "cloudfront:DeleteCachePolicy",
@@ -236,6 +232,17 @@ resource "aws_iam_role_policy" "github_actions_infra_deploy" {
             "aws:ResourceTag/franco:terraform_stack" = "francescoalbanese-dev-infra"
           }
         }
+      },
+      {
+        Sid    = "CloudFrontFunctions"
+        Effect = "Allow"
+        Action = [
+          "cloudfront:CreateFunction",
+          "cloudfront:UpdateFunction",
+          "cloudfront:DeleteFunction",
+          "cloudfront:PublishFunction"
+        ]
+        Resource = "arn:aws:cloudfront::${var.account_id}:function/*"
       },
       {
         Sid    = "ACMReadOnly"


### PR DESCRIPTION
## Summary
- CloudFront Functions aren't taggable, so the existing tag-based IAM condition was denying Create/Update/Delete/Publish actions
- Split those actions into a separate statement without the tag condition

## Test plan
- [ ] Deploy infra in sandbox and verify CloudFront Function actions succeed
- [ ] Confirm tag-based condition still applies to taggable CloudFront resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)