### PR TITLE
fix: switch CloudFront to v1 ACL logging, add ECR/SSM IAM perms

### DIFF
--- a/terraform/environmental/analytics.tf
+++ b/terraform/environmental/analytics.tf
@@ -35,9 +35,42 @@ resource "aws_s3_bucket" "analytics" {
 resource "aws_s3_bucket_ownership_controls" "analytics" {
   bucket = aws_s3_bucket.analytics.id
 
+  # BucketOwnerPreferred (not Enforced) because CloudFront v1 access logging
+  # writes via ACLs; v2 supported no-ACLs but is cross-region-locked.
   rule {
-    object_ownership = "BucketOwnerEnforced"
+    object_ownership = "BucketOwnerPreferred"
   }
+}
+
+data "aws_canonical_user_id" "current" {}
+
+resource "aws_s3_bucket_acl" "analytics" {
+  bucket = aws_s3_bucket.analytics.id
+
+  access_control_policy {
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+
+    grant {
+      grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "FULL_CONTROL"
+    }
+
+    # CloudFront log-delivery canonical user (static, AWS-owned).
+    grant {
+      grantee {
+        id   = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
+        type = "CanonicalUser"
+      }
+      permission = "FULL_CONTROL"
+    }
+  }
+
+  depends_on = [aws_s3_bucket_ownership_controls.analytics]
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "analytics" {
@@ -107,94 +140,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "analytics" {
   }
 }
 
-# ─── Analytics: CloudFront v2 standard logging → S3 ──────────────────────────
-
-resource "aws_cloudwatch_log_delivery_source" "cloudfront" {
-  provider = aws.us_east_1
-
-  name         = "${local.project_prefix}-cloudfront-access-logs"
-  resource_arn = aws_cloudfront_distribution.site.arn
-  log_type     = "ACCESS_LOGS"
-
-  tags = local.analytics_tags
-}
-
-resource "aws_cloudwatch_log_delivery_destination" "cloudfront_s3" {
-  provider = aws.us_east_1
-
-  name          = "${local.project_prefix}-cloudfront-s3"
-  output_format = "w3c"
-
-  delivery_destination_configuration {
-    destination_resource_arn = aws_s3_bucket.analytics.arn
-  }
-
-  tags = local.analytics_tags
-}
-
-resource "aws_cloudwatch_log_delivery" "cloudfront" {
-  provider = aws.us_east_1
-
-  delivery_source_name     = aws_cloudwatch_log_delivery_source.cloudfront.name
-  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.cloudfront_s3.arn
-
-  depends_on = [aws_s3_bucket_policy.analytics_cf_logs]
-
-  # Only the fields the log-enricher actually parses — trims storage + parse cost.
-  record_fields = [
-    "date",
-    "time",
-    "sc-bytes",
-    "c-ip",
-    "cs-method",
-    "cs-uri-stem",
-    "sc-status",
-    "cs(Referer)",
-    "cs(User-Agent)",
-  ]
-
-  s3_delivery_configuration {
-    suffix_path = "cf-logs"
-  }
-
-  tags = local.analytics_tags
-}
-
-resource "aws_s3_bucket_policy" "analytics_cf_logs" {
-  bucket = aws_s3_bucket.analytics.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid       = "AWSLogDeliveryWrite"
-        Effect    = "Allow"
-        Principal = { Service = "delivery.logs.amazonaws.com" }
-        Action    = "s3:PutObject"
-        Resource  = "${aws_s3_bucket.analytics.arn}/cf-logs/*"
-        Condition = {
-          StringEquals = {
-            "s3:x-amz-acl"      = "bucket-owner-full-control"
-            "aws:SourceAccount" = var.account_id
-          }
-          ArnLike = {
-            "aws:SourceArn" = "arn:aws:logs:us-east-1:${var.account_id}:delivery-source:*"
-          }
-        }
-      },
-      {
-        Sid       = "AWSLogDeliveryAclCheck"
-        Effect    = "Allow"
-        Principal = { Service = "delivery.logs.amazonaws.com" }
-        Action    = "s3:GetBucketAcl"
-        Resource  = aws_s3_bucket.analytics.arn
-        Condition = {
-          StringEquals = { "aws:SourceAccount" = var.account_id }
-        }
-      }
-    ]
-  })
-}
+# CloudFront v1 access logging writes directly to the analytics bucket via the
+# `logging_config` block on aws_cloudfront_distribution.site — see cloudfront.tf.
+# The ACL above grants the CF log-delivery canonical user write access.
 
 # ─── Analytics: IAM Roles ─────────────────────────────────────────────────────
 

--- a/terraform/environmental/cloudfront.tf
+++ b/terraform/environmental/cloudfront.tf
@@ -110,8 +110,15 @@ resource "aws_cloudfront_distribution" "site" {
   aliases             = [var.domain_name, "www.${var.domain_name}"]
   price_class         = "PriceClass_100"
 
-  # Access logs delivered via CloudWatch Logs delivery (CloudFront v2 standard
-  # logging) — configured in analytics.tf.
+  # CloudFront v1 access logging → analytics bucket (cf-logs/ prefix).
+  # Triggers the log-enricher Lambda via S3 ObjectCreated events.
+  logging_config {
+    bucket          = "${aws_s3_bucket.analytics.id}.s3.amazonaws.com"
+    prefix          = "cf-logs/"
+    include_cookies = false
+  }
+
+  depends_on = [aws_s3_bucket_acl.analytics]
 
   origin {
     domain_name              = aws_s3_bucket.site.bucket_regional_domain_name

--- a/terraform/environmental/oidc.tf
+++ b/terraform/environmental/oidc.tf
@@ -341,6 +341,38 @@ resource "aws_iam_role_policy" "github_actions_infra_deploy" {
         ]
         Resource = "arn:aws:iam::${var.account_id}:policy/${local.project_prefix}-infra-deploy-boundary"
       },
+      {
+        # GetAuthorizationToken is inherently registry-wide — AWS requires "*".
+        # The returned token is scoped to this account's registry.
+        Sid      = "EcrAuth"
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      },
+      {
+        Sid    = "EcrPushAnalyticsImages"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:PutImage",
+          "ecr:BatchGetImage",
+          "ecr:DescribeRepositories",
+          "ecr:DescribeImages"
+        ]
+        Resource = [
+          "arn:aws:ecr:${var.region}:${var.account_id}:repository/${local.project_prefix}-log-enricher",
+          "arn:aws:ecr:${var.region}:${var.account_id}:repository/${local.project_prefix}-dashboard-generator"
+        ]
+      },
+      {
+        Sid      = "SsmReadMaxMindLicense"
+        Effect   = "Allow"
+        Action   = "ssm:GetParameter"
+        Resource = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/${local.project_prefix}/maxmind-license-key"
+      },
     ]
   })
 }


### PR DESCRIPTION
## Summary
- Switched CloudFront access logging from v2 (CloudWatch delivery pipeline) to v1 `logging_config` — simpler, same-region, triggers log-enricher Lambda via S3 ObjectCreated
- Analytics bucket: `BucketOwnerPreferred` + explicit ACL granting CloudFront log-delivery canonical user write access (required for v1 logging)
- Removed `aws_cloudwatch_log_delivery_source/destination/delivery` and associated S3 bucket policy resources
- Added ECR push permissions (`BatchCheckLayerAvailability`, `InitiateLayerUpload`, etc.) to GitHub Actions deploy role for `log-enricher` and `dashboard-generator` repos
- Added `ssm:GetParameter` for MaxMind license key SSM path to deploy role

## Test plan
- [ ] `terraform plan` shows no unexpected destroy/replace on unrelated resources
- [ ] CloudFront distribution updates with `logging_config` block
- [ ] Analytics bucket ACL reflects CF log-delivery canonical user grant
- [ ] Verify CF access logs appear under `cf-logs/` prefix after deploy
- [ ] GitHub Actions can push images to ECR repos and read MaxMind SSM param

🤖 Generated with [Claude Code](https://claude.com/claude-code)