### PR TITLE
fix(lambda): hoist INCLUDE_GEOIP ARG to global scope for BuildKit

### DIFF
--- a/terraform/environmental/lambdas/Dockerfile.analytics
+++ b/terraform/environmental/lambdas/Dockerfile.analytics
@@ -1,5 +1,6 @@
 ARG LAMBDA_DIR
 ARG PACKAGE_NAME
+ARG INCLUDE_GEOIP=false
 FROM ghcr.io/astral-sh/uv:0.5 AS uv
 
 FROM public.ecr.aws/lambda/python:3.13-arm64 AS builder
@@ -21,11 +22,14 @@ FROM scratch AS geoip-false
 FROM scratch AS geoip-true
 COPY data/GeoLite2-City.mmdb /opt/GeoLite2-City.mmdb
 
+# Resolve conditional stage via global ARG (BuildKit disallows variable
+# expansion in --from, so indirect through an aliased FROM)
+FROM geoip-${INCLUDE_GEOIP} AS geoip
+
 FROM public.ecr.aws/lambda/python:3.13-arm64
 ARG PACKAGE_NAME
-ARG INCLUDE_GEOIP=false
 COPY --from=builder /app/.venv/lib/python3.13/site-packages ${LAMBDA_TASK_ROOT}
 COPY --from=builder /app/src/${PACKAGE_NAME} ${LAMBDA_TASK_ROOT}
-COPY --from=geoip-${INCLUDE_GEOIP} / /
+COPY --from=geoip / /
 
 CMD ["handler.handler"]


### PR DESCRIPTION
## Summary
- BuildKit disallows variable expansion in `--from`; `COPY --from=geoip-${INCLUDE_GEOIP}` was causing CI failures for both `dashboard-generator` and `log-enricher` lambda image builds since ffc6ce6
- Moves `ARG INCLUDE_GEOIP=false` to global scope and adds an intermediate `FROM geoip-${INCLUDE_GEOIP} AS geoip` stage so the final `COPY --from=geoip / /` uses a static alias
- Unblocks the Build Lambda Images workflow

## Test plan
- [ ] CI Build Lambda Images passes for dashboard-generator
- [ ] CI Build Lambda Images passes for log-enricher

🤖 Generated with [Claude Code](https://claude.com/claude-code)