### PR TITLE
fix(iam): grant infra deploy role full analytics stack permissions

### DIFF
--- a/terraform/environmental/analytics.tf
+++ b/terraform/environmental/analytics.tf
@@ -1,8 +1,7 @@
 # ─── Analytics: Locals ────────────────────────────────────────────────────────
+# analytics_bucket_name / analytics_bucket_arn live in main.tf alongside site
 
 locals {
-  analytics_bucket_name = "${local.project_prefix}-analytics-${var.account_id}"
-
   analytics_tags = {
     "franco:terraform_stack" = "francescoalbanese-dev-infra-analytics"
     "franco:environment"     = var.account_name
@@ -147,7 +146,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "analytics" {
 # ─── Analytics: IAM Roles ─────────────────────────────────────────────────────
 
 resource "aws_iam_role" "log_enricher" {
-  name = "${local.project_prefix}-log-enricher"
+  name                 = "${local.project_prefix}-log-enricher"
+  permissions_boundary = aws_iam_policy.infra_deploy_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -219,7 +219,8 @@ resource "aws_iam_role_policy" "log_enricher" {
 }
 
 resource "aws_iam_role" "dashboard_generator" {
-  name = "${local.project_prefix}-dashboard-generator"
+  name                 = "${local.project_prefix}-dashboard-generator"
+  permissions_boundary = aws_iam_policy.infra_deploy_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environmental/main.tf
+++ b/terraform/environmental/main.tf
@@ -1,7 +1,27 @@
 locals {
-  project_prefix   = "francescoalbanese-dev"
-  site_bucket_name = "${local.project_prefix}-site-${var.account_id}"
-  site_bucket_arn  = "arn:aws:s3:::${local.site_bucket_name}"
+  project_prefix        = "francescoalbanese-dev"
+  site_bucket_name      = "${local.project_prefix}-site-${var.account_id}"
+  site_bucket_arn       = "arn:aws:s3:::${local.site_bucket_name}"
+  analytics_bucket_name = "${local.project_prefix}-analytics-${var.account_id}"
+  analytics_bucket_arn  = "arn:aws:s3:::${local.analytics_bucket_name}"
+  managed_bucket_arns   = [local.site_bucket_arn, local.analytics_bucket_arn]
+
+  # Lambda analytics stack — predictable ARNs used by IAM policies
+  lambda_names = ["log-enricher", "dashboard-generator"]
+  lambda_role_arns = [
+    for n in local.lambda_names : "arn:aws:iam::${var.account_id}:role/${local.project_prefix}-${n}"
+  ]
+  lambda_function_arns = [
+    for n in local.lambda_names : "arn:aws:lambda:${var.region}:${var.account_id}:function:${local.project_prefix}-${n}"
+  ]
+  lambda_log_group_arns = [
+    for n in local.lambda_names : "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/lambda/${local.project_prefix}-${n}"
+  ]
+  lambda_log_group_arns_wildcard = [for a in local.lambda_log_group_arns : "${a}:*"]
+  analytics_alerts_topic_arn     = "arn:aws:sns:${var.region}:${var.account_id}:${local.project_prefix}-analytics-alerts"
+  ecr_lambda_repo_arns = [
+    for n in local.lambda_names : "arn:aws:ecr:${var.region}:${var.account_id}:repository/${local.project_prefix}-${n}"
+  ]
 }
 
 # Route53 hosted zone for francescoalbanese.dev (in shared-services, centralised DNS)

--- a/terraform/environmental/oidc.tf
+++ b/terraform/environmental/oidc.tf
@@ -105,7 +105,9 @@ resource "aws_iam_role" "github_actions_infra_deploy" {
   }
 }
 
-# Permissions boundary — caps privileges for any role created by infra deploy
+# Permissions boundary — caps privileges for any role created by infra deploy.
+# Covers both infra deploy roles (site sync + CF invalidation) and lambda
+# runtime roles (analytics bucket access + SNS publish + CloudWatch logs).
 resource "aws_iam_policy" "infra_deploy_boundary" {
   name        = "${local.project_prefix}-infra-deploy-boundary"
   description = "Permissions boundary for roles created by the infra deploy pipeline"
@@ -114,7 +116,7 @@ resource "aws_iam_policy" "infra_deploy_boundary" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "AllowS3"
+        Sid    = "AllowS3ManagedBuckets"
         Effect = "Allow"
         Action = [
           "s3:GetObject",
@@ -123,10 +125,10 @@ resource "aws_iam_policy" "infra_deploy_boundary" {
           "s3:ListBucket",
           "s3:GetBucketLocation"
         ]
-        Resource = [
-          local.site_bucket_arn,
-          "${local.site_bucket_arn}/*"
-        ]
+        Resource = concat(
+          local.managed_bucket_arns,
+          [for b in local.managed_bucket_arns : "${b}/*"]
+        )
       },
       {
         Sid      = "AllowCloudFrontInvalidation"
@@ -138,6 +140,21 @@ resource "aws_iam_policy" "infra_deploy_boundary" {
             "aws:ResourceTag/franco:terraform_stack" = "francescoalbanese-dev-infra"
           }
         }
+      },
+      {
+        Sid      = "AllowSNSPublishAnalyticsAlerts"
+        Effect   = "Allow"
+        Action   = ["sns:Publish"]
+        Resource = local.analytics_alerts_topic_arn
+      },
+      {
+        Sid    = "AllowCloudWatchLogsWrite"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = local.lambda_log_group_arns_wildcard
       }
     ]
   })
@@ -162,13 +179,22 @@ resource "aws_iam_role_policy" "github_actions_infra_deploy" {
         Resource = "arn:aws:iam::${var.shared_services_account_id}:role/${var.shared_services_role_name}"
       },
       {
-        Sid    = "S3"
+        # S3 bucket-level management on managed buckets (site + analytics).
+        # Object-level CRUD happens via the site-deploy role (see above) and
+        # via lambda runtime roles (see boundary), not here.
+        Sid    = "S3ManagedBuckets"
         Effect = "Allow"
         Action = [
           "s3:GetBucketPolicy",
           "s3:PutBucketPolicy",
+          "s3:DeleteBucketPolicy",
           "s3:GetBucketAcl",
+          "s3:PutBucketAcl",
+          "s3:GetBucketOwnershipControls",
+          "s3:PutBucketOwnershipControls",
+          "s3:DeleteBucketOwnershipControls",
           "s3:GetBucketCORS",
+          "s3:PutBucketCORS",
           "s3:GetBucketWebsite",
           "s3:GetBucketVersioning",
           "s3:GetBucketLogging",
@@ -179,16 +205,28 @@ resource "aws_iam_role_policy" "github_actions_infra_deploy" {
           "s3:PutBucketPublicAccessBlock",
           "s3:GetBucketRequestPayment",
           "s3:GetLifecycleConfiguration",
+          "s3:PutLifecycleConfiguration",
           "s3:GetReplicationConfiguration",
           "s3:GetEncryptionConfiguration",
           "s3:PutEncryptionConfiguration",
           "s3:GetAccelerateConfiguration",
+          "s3:GetBucketNotification",
+          "s3:PutBucketNotification",
           "s3:CreateBucket",
           "s3:DeleteBucket",
           "s3:ListBucket",
           "s3:PutBucketVersioning"
         ]
-        Resource = local.site_bucket_arn
+        Resource = local.managed_bucket_arns
+      },
+      {
+        # Required by data.aws_canonical_user_id (needed for CloudFront v1
+        # log-delivery ACL on the analytics bucket). ListAllMyBuckets is
+        # inherently global — cannot be ARN-scoped.
+        Sid      = "S3ListAllMyBuckets"
+        Effect   = "Allow"
+        Action   = "s3:ListAllMyBuckets"
+        Resource = "*"
       },
       {
         Sid    = "CloudFrontReadOnly"
@@ -316,13 +354,48 @@ resource "aws_iam_role_policy" "github_actions_infra_deploy" {
         Sid    = "IAMCreateRoleWithBoundary"
         Effect = "Allow"
         Action = "iam:CreateRole"
-        Resource = [
-          "arn:aws:iam::${var.account_id}:role/${local.project_prefix}-github-actions-deploy",
-          "arn:aws:iam::${var.account_id}:role/${local.project_prefix}-infra-github-actions-deploy"
-        ]
+        Resource = concat(
+          [
+            "arn:aws:iam::${var.account_id}:role/${local.project_prefix}-github-actions-deploy",
+            "arn:aws:iam::${var.account_id}:role/${local.project_prefix}-infra-github-actions-deploy"
+          ],
+          local.lambda_role_arns
+        )
         Condition = {
           StringEquals = {
             "iam:PermissionsBoundary" = aws_iam_policy.infra_deploy_boundary.arn
+          }
+        }
+      },
+      {
+        Sid    = "IAMManageLambdaExecRoles"
+        Effect = "Allow"
+        Action = [
+          "iam:GetRole",
+          "iam:DeleteRole",
+          "iam:UpdateRole",
+          "iam:TagRole",
+          "iam:UntagRole",
+          "iam:ListRolePolicies",
+          "iam:GetRolePolicy",
+          "iam:PutRolePolicy",
+          "iam:DeleteRolePolicy",
+          "iam:ListAttachedRolePolicies",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:PutRolePermissionsBoundary",
+          "iam:DeleteRolePermissionsBoundary"
+        ]
+        Resource = local.lambda_role_arns
+      },
+      {
+        Sid      = "IAMPassRoleToLambda"
+        Effect   = "Allow"
+        Action   = "iam:PassRole"
+        Resource = local.lambda_role_arns
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "lambda.amazonaws.com"
           }
         }
       },
@@ -350,7 +423,8 @@ resource "aws_iam_role_policy" "github_actions_infra_deploy" {
         Resource = "*"
       },
       {
-        Sid    = "EcrPushAnalyticsImages"
+        # Push + read (used by docker build-push + terraform data source refresh)
+        Sid    = "EcrPushAndRead"
         Effect = "Allow"
         Action = [
           "ecr:BatchCheckLayerAvailability",
@@ -359,13 +433,100 @@ resource "aws_iam_role_policy" "github_actions_infra_deploy" {
           "ecr:CompleteLayerUpload",
           "ecr:PutImage",
           "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer",
           "ecr:DescribeRepositories",
-          "ecr:DescribeImages"
+          "ecr:DescribeImages",
+          "ecr:ListImages",
+          "ecr:ListTagsForResource"
         ]
-        Resource = [
-          "arn:aws:ecr:${var.region}:${var.account_id}:repository/${local.project_prefix}-log-enricher",
-          "arn:aws:ecr:${var.region}:${var.account_id}:repository/${local.project_prefix}-dashboard-generator"
+        Resource = local.ecr_lambda_repo_arns
+      },
+      {
+        # Repo lifecycle management (terraform/ecr stack)
+        Sid    = "EcrManageRepos"
+        Effect = "Allow"
+        Action = [
+          "ecr:CreateRepository",
+          "ecr:DeleteRepository",
+          "ecr:TagResource",
+          "ecr:UntagResource",
+          "ecr:PutImageScanningConfiguration",
+          "ecr:PutImageTagMutability",
+          "ecr:PutLifecyclePolicy",
+          "ecr:GetLifecyclePolicy",
+          "ecr:DeleteLifecyclePolicy",
+          "ecr:SetRepositoryPolicy",
+          "ecr:GetRepositoryPolicy",
+          "ecr:DeleteRepositoryPolicy"
         ]
+        Resource = local.ecr_lambda_repo_arns
+      },
+      {
+        Sid    = "LambdaManageAnalyticsFunctions"
+        Effect = "Allow"
+        Action = [
+          "lambda:CreateFunction",
+          "lambda:DeleteFunction",
+          "lambda:GetFunction",
+          "lambda:GetFunctionConfiguration",
+          "lambda:GetFunctionCodeSigningConfig",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
+          "lambda:ListVersionsByFunction",
+          "lambda:TagResource",
+          "lambda:UntagResource",
+          "lambda:ListTags",
+          "lambda:AddPermission",
+          "lambda:RemovePermission",
+          "lambda:GetPolicy",
+          "lambda:PutFunctionConcurrency",
+          "lambda:DeleteFunctionConcurrency"
+        ]
+        Resource = local.lambda_function_arns
+      },
+      {
+        # DescribeLogGroups is required on refresh; it must target a log-group
+        # prefix (AWS does not allow it against a specific log-group ARN).
+        Sid      = "LogsDescribeLambdaGroups"
+        Effect   = "Allow"
+        Action   = "logs:DescribeLogGroups"
+        Resource = "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/lambda/${local.project_prefix}-*"
+      },
+      {
+        Sid    = "LogsManageLambdaGroups"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:DeleteLogGroup",
+          "logs:PutRetentionPolicy",
+          "logs:DeleteRetentionPolicy",
+          "logs:TagResource",
+          "logs:UntagResource",
+          "logs:ListTagsForResource",
+          "logs:ListTagsLogGroup"
+        ]
+        Resource = concat(
+          local.lambda_log_group_arns,
+          local.lambda_log_group_arns_wildcard
+        )
+      },
+      {
+        Sid    = "SnsManageAnalyticsAlerts"
+        Effect = "Allow"
+        Action = [
+          "sns:CreateTopic",
+          "sns:DeleteTopic",
+          "sns:GetTopicAttributes",
+          "sns:SetTopicAttributes",
+          "sns:ListTagsForResource",
+          "sns:TagResource",
+          "sns:UntagResource",
+          "sns:Subscribe",
+          "sns:Unsubscribe",
+          "sns:GetSubscriptionAttributes",
+          "sns:ListSubscriptionsByTopic"
+        ]
+        Resource = local.analytics_alerts_topic_arn
       },
       {
         Sid      = "SsmReadMaxMindLicense"


### PR DESCRIPTION
## Summary

- terraform-deploy was failing on refresh of analytics resources due to missing IAM perms on the infra deploy role
- adds S3 bucket-level ops on analytics bucket (ACL, ownership, lifecycle, notification, PAB, encryption), ECR repo management, Lambda CRUD + PassRole, CloudWatch Logs CRUD, SNS topic+subscription management, and `s3:ListAllMyBuckets` (for `data.aws_canonical_user_id`)
- extends permissions boundary to cover lambda runtime roles (analytics bucket object R/W, SNS Publish, CloudWatch log writes)
- attaches boundary to both lambda exec roles
- consolidates `analytics_bucket_name` local into `main.tf` (was duplicated in `analytics.tf`)

## Test plan

- [ ] CI `Terraform Plan` passes on this PR
- [ ] On merge, `Terraform Apply` completes the analytics stack with no AccessDenied errors