### PR TITLE
fix(analytics): filter bot/scanner noise, drop deep-browse alert

### DIFF
--- a/terraform/environmental/analytics.tf
+++ b/terraform/environmental/analytics.tf
@@ -112,7 +112,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "analytics" {
       prefix = "enriched/"
     }
     expiration {
-      days = 90
+      days = 14
     }
   }
 

--- a/terraform/environmental/functions/src/redirect-www-to-bare.ts
+++ b/terraform/environmental/functions/src/redirect-www-to-bare.ts
@@ -1,14 +1,37 @@
+// Scanner probes. Unanchored: scanners fan out across nested prefixes
+// (`/site/wp-includes/...`) and send leading double-slashes (`//xmlrpc.php`).
+const SCANNER_PATH =
+	/\/xmlrpc\.php|\/\.git(\/|$)|\/\.env|\/\.aws|\/\.ssh|\/\.vscode|\/\.DS_Store|\/wp-(admin|login|content|includes|config)|\/wlwmanifest\.xml|\/phpmyadmin|\/adminer|\/phpinfo|^\/\/|:\/\/|\/https?\//i;
+
+// Non-human clients. Narrow regex by design — 1ms CPU budget.
+const BOT_UA =
+	/curl|wget|python-requests|python-urllib|go-http-client|okhttp|libwww-perl|masscan|nmap|nikto|nuclei|zgrab|scrapy|httpx|gobuster|feroxbuster/i;
+
+const FORBIDDEN: AWSCloudFrontFunction.Response = {
+	statusCode: 403,
+	statusDescription: "Forbidden",
+};
+
 export function handler(
 	event: AWSCloudFrontFunction.Event,
 ): AWSCloudFrontFunction.Request | AWSCloudFrontFunction.Response {
-	const host = event.request.headers.host.value;
+	const uri = event.request.uri;
+	if (SCANNER_PATH.test(uri)) {
+		return FORBIDDEN;
+	}
 
+	const ua = event.request.headers["user-agent"]?.value ?? "";
+	if (BOT_UA.test(ua)) {
+		return FORBIDDEN;
+	}
+
+	const host = event.request.headers.host.value;
 	if (host === "www." + __DOMAIN__) {
 		return {
 			statusCode: 301,
 			headers: {
 				location: {
-					value: "https://" + __DOMAIN__ + event.request.uri,
+					value: "https://" + __DOMAIN__ + uri,
 				},
 			},
 		};

--- a/terraform/environmental/lambdas/dashboard-generator/src/dashboard_generator/handler.py
+++ b/terraform/environmental/lambdas/dashboard-generator/src/dashboard_generator/handler.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 BUCKET = os.environ.get("ANALYTICS_BUCKET", "")
-DASHBOARD_WINDOW_DAYS = 30
+DASHBOARD_WINDOW_DAYS = 14
 PRESIGN_EXPIRY_SECONDS = 3600
 
 s3 = boto3.client("s3")
@@ -28,11 +28,9 @@ STATIC_ASSET_PATTERNS = re.compile(
     r")"
 )
 
-TARGET_COUNTRIES = {"United Kingdom", "United States"}
 SELF_DOMAINS = {"francescoalbanese.dev", "www.francescoalbanese.dev"}
 MOBILE_PATTERNS = re.compile(r"(?i)(iphone|android|mobile|ipod|blackberry|opera mini)")
 
-DEEP_BROWSE_MIN_PAGES = 3
 CITY_CLUSTER_MIN_IPS = 3
 
 
@@ -113,37 +111,6 @@ def compute_top_pages(records: list[EnrichedRecord], limit: int = 10) -> list[di
     return [{"path": path, "count": count} for path, count in sorted_pages]
 
 
-def compute_deep_browsers(records: list[EnrichedRecord]) -> list[dict[str, object]]:
-    ip_data: dict[str, EnrichedRecord] = {}
-    ip_pages: dict[str, set[str]] = defaultdict(set)
-
-    for r in records:
-        if r["country"] not in TARGET_COUNTRIES:
-            continue
-        if is_static_asset(r["path"]):
-            continue
-        ip_pages[r["client_ip"]].add(r["path"])
-        ip_data[r["client_ip"]] = r
-
-    browsers: list[dict[str, object]] = []
-    for ip, pages in ip_pages.items():
-        if len(pages) < DEEP_BROWSE_MIN_PAGES:
-            continue
-        meta = ip_data[ip]
-        browsers.append(
-            {
-                "client_ip": ip,
-                "city": meta["city"],
-                "country": meta["country"],
-                "pages": sorted(pages),
-                "user_agent": meta["user_agent"],
-                "rdns": meta.get("rdns", ""),
-                "referer": meta.get("referer", ""),
-            }
-        )
-    return browsers
-
-
 def compute_referrers(records: list[EnrichedRecord], limit: int = 10) -> list[dict[str, object]]:
     domain_counts: dict[str, int] = defaultdict(int)
     for r in records:
@@ -200,17 +167,6 @@ def compute_daily_trend(
 
 def compute_alert_history(records: list[EnrichedRecord]) -> list[dict[str, object]]:
     alerts: list[dict[str, object]] = []
-    for browser in compute_deep_browsers(records):
-        alerts.append(
-            {
-                "type": "deep_browse",
-                "city": browser["city"],
-                "country": browser["country"],
-                "pages": browser["pages"],
-                "rdns": browser.get("rdns", ""),
-            }
-        )
-
     city_ips: dict[str, set[str]] = defaultdict(set)
     for r in records:
         if r["city"]:
@@ -233,7 +189,6 @@ def handler(event: dict, context: object) -> dict:
         "visits": compute_visits(records, now),
         "top_cities": compute_top_cities(records),
         "top_pages": compute_top_pages(records),
-        "deep_browsers": compute_deep_browsers(records),
         "referrers": compute_referrers(records),
         "ua_breakdown": compute_ua_breakdown(records),
         "daily_trend": compute_daily_trend(records, now),

--- a/terraform/environmental/lambdas/dashboard-generator/src/dashboard_generator/template.html
+++ b/terraform/environmental/lambdas/dashboard-generator/src/dashboard_generator/template.html
@@ -49,7 +49,6 @@
       font-size: 0.75rem;
       margin: 2px;
     }
-    .alert-deep { border-left: 3px solid #f0883e; }
     .alert-cluster { border-left: 3px solid #58a6ff; }
     canvas { max-height: 300px; }
     .loading { text-align: center; padding: 48px; color: #8b949e; }
@@ -63,7 +62,7 @@
 
   <div class="grid grid-2">
     <div class="card">
-      <h2>Daily Visit Trend (30 days)</h2>
+      <h2>Daily Visit Trend (14 days)</h2>
       <canvas id="trend-chart"></canvas>
     </div>
     <div class="card">
@@ -83,15 +82,9 @@
     </div>
   </div>
 
-  <div class="grid grid-2" style="margin-top:16px">
-    <div class="card">
-      <h2>Referrers</h2>
-      <table id="referrers-table"><thead><tr><th>Domain</th><th>Count</th></tr></thead><tbody></tbody></table>
-    </div>
-    <div class="card">
-      <h2>Deep Browsers (London/US, 3+ pages)</h2>
-      <div id="deep-browsers"></div>
-    </div>
+  <div class="card" style="margin-top:16px">
+    <h2>Referrers</h2>
+    <table id="referrers-table"><thead><tr><th>Domain</th><th>Count</th></tr></thead><tbody></tbody></table>
   </div>
 
   <div class="card" style="margin-top:16px">
@@ -145,7 +138,6 @@
       renderTable('cities-table', data.top_cities, r => '<td>' + esc(r.city) + '</td><td>' + r.count + '</td>');
       renderTable('pages-table', data.top_pages, r => '<td>' + esc(r.path) + '</td><td>' + r.count + '</td>');
       renderTable('referrers-table', data.referrers, r => '<td>' + esc(r.domain) + '</td><td>' + r.count + '</td>');
-      renderDeepBrowsers(data.deep_browsers);
       renderAlertHistory(data.alert_history);
     }
 
@@ -201,36 +193,15 @@
       });
     }
 
-    function renderDeepBrowsers(browsers) {
-      const container = document.getElementById('deep-browsers');
-      if (!browsers.length) { container.innerHTML = '<p style="color:#8b949e;font-size:0.85rem">No deep browse sessions</p>'; return; }
-      browsers.forEach(b => {
-        const div = document.createElement('div');
-        div.className = 'card alert-deep';
-        div.style.marginBottom = '8px';
-        div.innerHTML =
-          '<strong>' + esc(b.city) + ', ' + esc(b.country) + '</strong>' +
-          (b.rdns ? ' <span style="color:#8b949e">(' + esc(b.rdns) + ')</span>' : '') +
-          '<div style="margin:4px 0">' + b.pages.map(p => '<span class="tag">' + esc(p) + '</span>').join('') + '</div>' +
-          '<div style="font-size:0.75rem;color:#8b949e">' + esc(b.user_agent.slice(0, 80)) + '...</div>';
-        container.appendChild(div);
-      });
-    }
-
     function renderAlertHistory(alerts) {
       const container = document.getElementById('alert-history');
       if (!alerts.length) { container.innerHTML = '<p style="color:#8b949e;font-size:0.85rem">No alerts</p>'; return; }
       alerts.forEach(a => {
         const div = document.createElement('div');
-        div.className = 'card ' + (a.type === 'deep_browse' ? 'alert-deep' : 'alert-cluster');
+        div.className = 'card alert-cluster';
         div.style.marginBottom = '8px';
-        if (a.type === 'deep_browse') {
-          div.innerHTML = '<strong>Deep Browse</strong> &mdash; ' + esc(a.city) + ', ' + esc(a.country) +
-            '<div>' + a.pages.map(p => '<span class="tag">' + esc(p) + '</span>').join('') + '</div>';
-        } else {
-          div.innerHTML = '<strong>City Cluster</strong> &mdash; ' + esc(a.city) +
-            ' (' + a.unique_visitors + ' unique visitors)';
-        }
+        div.innerHTML = '<strong>City Cluster</strong> &mdash; ' + esc(a.city) +
+          ' (' + a.unique_visitors + ' unique visitors)';
         container.appendChild(div);
       });
     }

--- a/terraform/environmental/lambdas/dashboard-generator/tests/test_handler.py
+++ b/terraform/environmental/lambdas/dashboard-generator/tests/test_handler.py
@@ -24,13 +24,12 @@ def get_dashboard_data(s3_client) -> dict:
 
 class TestVisitsByPeriod:
     def test_counts_today_this_week_this_month(self, s3_client):
-        # Freeze `now` at a midweek day so `this_week` (Mon-based) has room
-        # for prior-day records — otherwise the test fails when run on a Monday.
-        frozen_now = datetime(2026, 4, 15, 12, 0, 0, tzinfo=UTC)
+        # Freeze `now` at a Friday so `this_week` (Mon-based) has room for a
+        # prior-day record and day-1-of-month falls within the 14-day window.
+        frozen_now = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
         today = frozen_now.date()
         yesterday = today - timedelta(days=1)
         this_month_only = today.replace(day=1)
-        window_only = today - timedelta(days=20)
 
         def ts(d: date) -> str:
             return f"{d.isoformat()}T12:00:00Z"
@@ -55,12 +54,6 @@ class TestVisitsByPeriod:
             this_month_only.isoformat(),
             [make_record(timestamp=ts(this_month_only))],
             suffix="c",
-        )
-        upload_enriched_records(
-            s3_client,
-            window_only.isoformat(),
-            [make_record(timestamp=ts(window_only))],
-            suffix="d",
         )
 
         with patch("dashboard_generator.handler.datetime") as mock_dt:
@@ -130,76 +123,6 @@ class TestTopPages:
 
         assert data["top_pages"][0]["path"] == "/"
         assert data["top_pages"][0]["count"] == 2
-
-
-class TestDeepBrowsers:
-    def test_detects_london_ip_with_3_plus_pages(self, s3_client):
-        today = date_str(0)
-        records = [
-            make_record(
-                client_ip="203.0.113.1",
-                path="/",
-                city="London",
-                country="United Kingdom",
-                rdns="host.barclays.co.uk",
-                timestamp=timestamp_str(0),
-            ),
-            make_record(
-                client_ip="203.0.113.1",
-                path="/projects",
-                city="London",
-                country="United Kingdom",
-                timestamp=timestamp_str(0),
-            ),
-            make_record(
-                client_ip="203.0.113.1",
-                path="/cv",
-                city="London",
-                country="United Kingdom",
-                timestamp=timestamp_str(0),
-            ),
-        ]
-        upload_enriched_records(s3_client, today, records)
-
-        invoke_handler(s3_client)
-        data = get_dashboard_data(s3_client)
-
-        assert len(data["deep_browsers"]) == 1
-        browser = data["deep_browsers"][0]
-        assert browser["city"] == "London"
-        assert set(browser["pages"]) == {"/", "/projects", "/cv"}
-
-    def test_excludes_non_target_geo(self, s3_client):
-        today = date_str(0)
-        records = [
-            make_record(
-                client_ip="1.1.1.1",
-                path="/",
-                city="Berlin",
-                country="Germany",
-                timestamp=timestamp_str(0),
-            ),
-            make_record(
-                client_ip="1.1.1.1",
-                path="/projects",
-                city="Berlin",
-                country="Germany",
-                timestamp=timestamp_str(0),
-            ),
-            make_record(
-                client_ip="1.1.1.1",
-                path="/cv",
-                city="Berlin",
-                country="Germany",
-                timestamp=timestamp_str(0),
-            ),
-        ]
-        upload_enriched_records(s3_client, today, records)
-
-        invoke_handler(s3_client)
-        data = get_dashboard_data(s3_client)
-
-        assert len(data["deep_browsers"]) == 0
 
 
 class TestReferrers:
@@ -307,7 +230,7 @@ class TestDailyTrend:
         invoke_handler(s3_client)
         data = get_dashboard_data(s3_client)
 
-        assert len(data["daily_trend"]) == 30
+        assert len(data["daily_trend"]) == 14
         today_entry = next(d for d in data["daily_trend"] if d["date"] == today)
         assert today_entry["count"] == 1
 

--- a/terraform/environmental/lambdas/log-enricher/src/log_enricher/handler.py
+++ b/terraform/environmental/lambdas/log-enricher/src/log_enricher/handler.py
@@ -30,9 +30,28 @@ BOT_PATTERNS = re.compile(
     r"(?i)("
     r"googlebot|bingbot|crawl|slurp|duckduckbot|baiduspider|yandexbot|"
     r"facebookexternalhit|twitterbot|linkedinbot|petalbot|semrushbot|"
-    r"ahrefsbot|mj12bot|bytespider"
+    r"ahrefsbot|mj12bot|bytespider|"
+    r"curl|wget|python-requests|python-urllib|go-http-client|java/|okhttp|"
+    r"libwww-perl|masscan|nmap|nikto|nuclei|zgrab|scrapy|httpx|"
+    r"axios-core|node-fetch|ruby|rustyscan|gobuster|feroxbuster"
     r")"
 )
+
+# Scanner probe paths. Patterns are unanchored on purpose — scanners fan out
+# across nested prefixes like `/site/wp-includes/...` and CloudFront preserves
+# leading double-slashes (`//xmlrpc.php`). `://` catches URL-injection stems
+# verbatim; `/https?/` catches the CF-normalized form where `://` collapsed to
+# `/` — e.g. `/Alvin9999/https/fanfan1.net/daohang/`.
+SCANNER_PATH_PATTERNS = re.compile(
+    r"(?i)("
+    r"/xmlrpc\.php|/\.git(/|$)|/\.env|/\.aws|/\.ssh|/\.vscode|/\.DS_Store|"
+    r"/wp-(admin|login|content|includes|config)|/wlwmanifest\.xml|"
+    r"/phpmyadmin|/adminer|/phpinfo|"
+    r"^//|://|/https?/"
+    r")"
+)
+
+ALLOWED_METHODS = {"GET", "HEAD"}
 
 STATIC_ASSET_PATTERNS = re.compile(
     r"(?i)("
@@ -48,9 +67,6 @@ DATE_IN_KEY = re.compile(r"(\d{4})[-/](\d{2})[-/](\d{2})")
 
 SLUG_STRIP = re.compile(r"[^a-z0-9]+")
 
-TARGET_COUNTRIES = {"United Kingdom", "United States"}
-
-DEEP_BROWSE_MIN_PAGES = 3
 CITY_CLUSTER_MIN_IPS = 3
 
 
@@ -82,8 +98,8 @@ class EnrichedRecord(TypedDict):
 
 @dataclass(frozen=True)
 class Alert:
-    type: str  # "deep_browse" | "city_cluster"
-    dedup_id: str  # ip for deep_browse, slugified city for city_cluster
+    type: str  # "city_cluster"
+    dedup_id: str  # slugified city
     message: str
 
 
@@ -105,6 +121,10 @@ def reverse_dns(ip: str) -> str:
 
 def is_bot(user_agent: str) -> bool:
     return bool(BOT_PATTERNS.search(user_agent))
+
+
+def is_scanner_path(path: str) -> bool:
+    return bool(SCANNER_PATH_PATTERNS.search(path))
 
 
 def is_static_asset(path: str) -> bool:
@@ -179,6 +199,12 @@ def enrich_entry(
     if is_bot(user_agent):
         return None
 
+    if entry["method"] not in ALLOWED_METHODS:
+        return None
+
+    if is_scanner_path(entry["uri_stem"]):
+        return None
+
     ip = entry["c_ip"]
     city = ""
     country = ""
@@ -216,37 +242,6 @@ def enrich_entry(
     )
 
 
-def check_deep_browse(records: list[EnrichedRecord]) -> list[Alert]:
-    ip_pages: dict[str, set[str]] = defaultdict(set)
-    ip_meta: dict[str, EnrichedRecord] = {}
-
-    for r in records:
-        if r["country"] not in TARGET_COUNTRIES:
-            continue
-        if is_static_asset(r["path"]):
-            continue
-        ip_pages[r["client_ip"]].add(r["path"])
-        ip_meta[r["client_ip"]] = r
-
-    alerts: list[Alert] = []
-    for ip, pages in ip_pages.items():
-        if len(pages) < DEEP_BROWSE_MIN_PAGES:
-            continue
-        meta = ip_meta[ip]
-        page_list = "\n".join(f"  \u2022 {p}" for p in sorted(pages))
-        message = (
-            f"\U0001f514 Deep Browse Alert \u2014 {meta['city']}, {meta['country']}\n\n"
-            f"A visitor from {meta['city']} browsed {len(pages)} pages on your site:\n"
-            f"{page_list}\n\n"
-            f"User-Agent: {meta['user_agent']}\n"
-            f"Referer: {meta['referer'] or 'direct'}\n"
-            f"Reverse DNS: {meta['rdns'] or 'N/A'}\n"
-            f"Time: {meta['timestamp']}"
-        )
-        alerts.append(Alert(type="deep_browse", dedup_id=ip, message=message))
-    return alerts
-
-
 def check_city_cluster(records: list[EnrichedRecord]) -> list[Alert]:
     city_ips: dict[str, set[str]] = defaultdict(set)
     for r in records:
@@ -258,7 +253,7 @@ def check_city_cluster(records: list[EnrichedRecord]) -> list[Alert]:
         if len(ips) < CITY_CLUSTER_MIN_IPS:
             continue
         message = (
-            f"\U0001f514 City Cluster Alert \u2014 {city}\n\n"
+            f"\U0001f514 City Cluster Alert — {city}\n\n"
             f"{len(ips)} unique visitors from {city} visited your site today."
         )
         alerts.append(Alert(type="city_cluster", dedup_id=slugify(city), message=message))
@@ -282,7 +277,7 @@ def publish_alert(alert: Alert, date_str: str) -> None:
         raise
     sns.publish(
         TopicArn=SNS_TOPIC_ARN,
-        Subject="francescoalbanese.dev \u2014 Visitor Alert",
+        Subject="francescoalbanese.dev — Visitor Alert",
         Message=alert.message,
     )
 
@@ -332,9 +327,6 @@ def handler(event: dict, context: object) -> None:
 
     day_prefix = f"enriched/{date_partition}/"
     day_records = load_records_for_prefix(day_prefix)
-
-    for alert in check_deep_browse(day_records):
-        publish_alert(alert, date_str)
 
     for alert in check_city_cluster(day_records):
         publish_alert(alert, date_str)

--- a/terraform/environmental/lambdas/log-enricher/tests/test_handler.py
+++ b/terraform/environmental/lambdas/log-enricher/tests/test_handler.py
@@ -107,6 +107,32 @@ class TestBotFiltering:
         records = get_enriched_records(s3)
         assert len(records) == 1
 
+    def test_filters_out_scanner_user_agents(self, aws_clients, mock_geoip_reader):
+        s3, _ = aws_clients
+        log_key = "cf-logs/E1234.2026-04-14-15.scannerua.gz"
+        scanner_agents = [
+            "curl/8.4.0",
+            "Wget/1.21.4",
+            "python-requests/2.31.0",
+            "Go-http-client/2.0",
+            "masscan/1.3.2",
+            "Nikto/2.5.0",
+            "Nuclei/3.0.0",
+        ]
+        lines = [make_cf_log_line(user_agent=ua) for ua in scanner_agents]
+        lines.append(make_cf_log_line(user_agent="Mozilla/5.0+real+user", c_ip="203.0.113.1"))
+        log_content = build_cf_log(lines)
+        upload_cf_log(s3, log_key, log_content)
+        event = make_s3_event(BUCKET_NAME, log_key)
+
+        with patch("log_enricher.handler.get_geoip_reader", return_value=mock_geoip_reader):
+            from log_enricher.handler import handler
+
+            handler(event, None)
+
+        records = get_enriched_records(s3)
+        assert len(records) == 1
+
     def test_all_bot_traffic_produces_empty_enriched_file(self, aws_clients, mock_geoip_reader):
         s3, _ = aws_clients
         log_key = "cf-logs/E1234.2026-04-14-15.allbot.gz"
@@ -126,6 +152,80 @@ class TestBotFiltering:
 
         records = get_enriched_records(s3)
         assert len(records) == 0
+
+
+class TestScannerPathFiltering:
+    def test_drops_known_scanner_probes(self, aws_clients, mock_geoip_reader):
+        s3, _ = aws_clients
+        log_key = "cf-logs/E1234.2026-04-14-15.scanpaths.gz"
+        scanner_paths = [
+            "/xmlrpc.php",
+            "//xmlrpc.php",
+            "/.git/config",
+            "/.env",
+            "/wp-login.php",
+            "/wp-admin/admin-ajax.php",
+            "/phpmyadmin/index.php",
+            "//site/wp-includes/wlwmanifest.xml",
+            "//wordpress/wp-includes/wlwmanifest.xml",
+            "/Alvin9999/https/fanfan1.net/daohang/",
+        ]
+        lines = [make_cf_log_line(uri_stem=p) for p in scanner_paths]
+        lines.append(make_cf_log_line(uri_stem="/", c_ip="203.0.113.1"))
+        log_content = build_cf_log(lines)
+        upload_cf_log(s3, log_key, log_content)
+        event = make_s3_event(BUCKET_NAME, log_key)
+
+        with patch("log_enricher.handler.get_geoip_reader", return_value=mock_geoip_reader):
+            from log_enricher.handler import handler
+
+            handler(event, None)
+
+        records = get_enriched_records(s3)
+        assert len(records) == 1
+        assert records[0]["path"] == "/"
+
+    def test_legit_paths_survive(self, aws_clients, mock_geoip_reader):
+        s3, _ = aws_clients
+        log_key = "cf-logs/E1234.2026-04-14-15.legitpaths.gz"
+        legit_paths = ["/", "/projects", "/cv", "/about", "/_astro/chunk.abc.js"]
+        lines = [make_cf_log_line(uri_stem=p, c_ip="203.0.113.1") for p in legit_paths]
+        log_content = build_cf_log(lines)
+        upload_cf_log(s3, log_key, log_content)
+        event = make_s3_event(BUCKET_NAME, log_key)
+
+        with patch("log_enricher.handler.get_geoip_reader", return_value=mock_geoip_reader):
+            from log_enricher.handler import handler
+
+            handler(event, None)
+
+        records = get_enriched_records(s3)
+        assert len(records) == len(legit_paths)
+
+
+class TestMethodFiltering:
+    def test_drops_non_get_head(self, aws_clients, mock_geoip_reader):
+        s3, _ = aws_clients
+        log_key = "cf-logs/E1234.2026-04-14-15.methods.gz"
+        lines = [
+            make_cf_log_line(method="POST", c_ip="203.0.113.1"),
+            make_cf_log_line(method="OPTIONS", c_ip="203.0.113.1"),
+            make_cf_log_line(method="DELETE", c_ip="203.0.113.1"),
+            make_cf_log_line(method="GET", c_ip="203.0.113.2"),
+            make_cf_log_line(method="HEAD", c_ip="203.0.113.3"),
+        ]
+        log_content = build_cf_log(lines)
+        upload_cf_log(s3, log_key, log_content)
+        event = make_s3_event(BUCKET_NAME, log_key)
+
+        with patch("log_enricher.handler.get_geoip_reader", return_value=mock_geoip_reader):
+            from log_enricher.handler import handler
+
+            handler(event, None)
+
+        records = get_enriched_records(s3)
+        assert len(records) == 2
+        assert {r["method"] for r in records} == {"GET", "HEAD"}
 
 
 class TestGeoIPEnrichment:
@@ -176,87 +276,6 @@ class TestGeoIPEnrichment:
         assert len(records) == 1
         assert records[0]["city"] == ""
         assert records[0]["country"] == ""
-
-
-class TestDeepBrowseAlert:
-    def test_fires_when_london_ip_visits_3_plus_pages(self, aws_clients, mock_geoip_reader):
-        s3, sns = aws_clients
-        log_key = "cf-logs/E1234.2026-04-14-15.deep1.gz"
-        log_content = build_cf_log(
-            [
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/"),
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/projects"),
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/cv"),
-            ]
-        )
-        upload_cf_log(s3, log_key, log_content)
-        event = make_s3_event(BUCKET_NAME, log_key)
-
-        with (
-            patch("log_enricher.handler.get_geoip_reader", return_value=mock_geoip_reader),
-            patch("log_enricher.handler.reverse_dns", return_value="host.example.com"),
-            patch("log_enricher.handler.publish_alert") as mock_publish,
-        ):
-            from log_enricher.handler import handler
-
-            handler(event, None)
-
-        mock_publish.assert_called()
-        alert = mock_publish.call_args[0][0]
-        assert alert.type == "deep_browse"
-        assert alert.dedup_id == "203.0.113.1"
-        assert "Deep Browse" in alert.message
-        assert "London" in alert.message
-
-    def test_excludes_static_assets_from_page_count(self, aws_clients, mock_geoip_reader):
-        s3, sns = aws_clients
-        log_key = "cf-logs/E1234.2026-04-14-15.static1.gz"
-        log_content = build_cf_log(
-            [
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/"),
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/_astro/chunk.abc123.js"),
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/favicon.ico"),
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/robots.txt"),
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/og.png"),
-            ]
-        )
-        upload_cf_log(s3, log_key, log_content)
-        event = make_s3_event(BUCKET_NAME, log_key)
-
-        with (
-            patch("log_enricher.handler.get_geoip_reader", return_value=mock_geoip_reader),
-            patch("log_enricher.handler.reverse_dns", return_value=""),
-            patch("log_enricher.handler.publish_alert") as mock_publish,
-        ):
-            from log_enricher.handler import handler
-
-            handler(event, None)
-
-        mock_publish.assert_not_called()
-
-    def test_does_not_fire_for_non_target_geo(self, aws_clients, mock_geoip_reader):
-        s3, sns = aws_clients
-        log_key = "cf-logs/E1234.2026-04-14-15.nontarget.gz"
-        log_content = build_cf_log(
-            [
-                make_cf_log_line(c_ip="192.0.2.1", uri_stem="/"),
-                make_cf_log_line(c_ip="192.0.2.1", uri_stem="/projects"),
-                make_cf_log_line(c_ip="192.0.2.1", uri_stem="/cv"),
-            ]
-        )
-        upload_cf_log(s3, log_key, log_content)
-        event = make_s3_event(BUCKET_NAME, log_key)
-
-        with (
-            patch("log_enricher.handler.get_geoip_reader", return_value=mock_geoip_reader),
-            patch("log_enricher.handler.reverse_dns", return_value=""),
-            patch("log_enricher.handler.publish_alert") as mock_publish,
-        ):
-            from log_enricher.handler import handler
-
-            handler(event, None)
-
-        mock_publish.assert_not_called()
 
 
 class TestCityClusterAlert:
@@ -326,14 +345,14 @@ class TestEdgeCases:
 
 
 class TestAlertDeduplication:
-    def test_same_alert_not_sent_twice(self, aws_clients, mock_geoip_reader):
+    def test_same_city_cluster_alert_not_sent_twice(self, aws_clients, mock_geoip_reader):
         s3, sns = aws_clients
 
         log_content = build_cf_log(
             [
                 make_cf_log_line(c_ip="203.0.113.1", uri_stem="/"),
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/projects"),
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/cv"),
+                make_cf_log_line(c_ip="203.0.113.2", uri_stem="/"),
+                make_cf_log_line(c_ip="203.0.113.3", uri_stem="/"),
             ]
         )
 
@@ -391,14 +410,14 @@ class TestRdnsCache:
 
 
 class TestAlertMarkerKey:
-    def test_dedup_marker_uses_type_date_ip(self, aws_clients, mock_geoip_reader):
+    def test_dedup_marker_uses_type_date_city(self, aws_clients, mock_geoip_reader):
         s3, _ = aws_clients
         log_key = "cf-logs/E1234.2026-04-14-15.marker.gz"
         log_content = build_cf_log(
             [
                 make_cf_log_line(c_ip="203.0.113.1", uri_stem="/"),
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/projects"),
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/cv"),
+                make_cf_log_line(c_ip="203.0.113.2", uri_stem="/"),
+                make_cf_log_line(c_ip="203.0.113.3", uri_stem="/"),
             ]
         )
         upload_cf_log(s3, log_key, log_content)
@@ -412,40 +431,6 @@ class TestAlertMarkerKey:
 
             handler(event, None)
 
-        response = s3.list_objects_v2(Bucket=BUCKET_NAME, Prefix="alerts/deep_browse/2026-04-14/")
+        response = s3.list_objects_v2(Bucket=BUCKET_NAME, Prefix="alerts/city_cluster/2026-04-14/")
         keys = [obj["Key"] for obj in response.get("Contents", [])]
-        assert "alerts/deep_browse/2026-04-14/203.0.113.1.sent" in keys
-
-
-class TestAlertMessageContent:
-    def test_deep_browse_alert_includes_pages_ua_rdns_referer(self, aws_clients, mock_geoip_reader):
-        s3, sns = aws_clients
-        log_key = "cf-logs/E1234.2026-04-14-15.alertcontent.gz"
-        log_content = build_cf_log(
-            [
-                make_cf_log_line(
-                    c_ip="203.0.113.1",
-                    uri_stem="/",
-                    referer="https://linkedin.com/in/recruiter",
-                ),
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/projects"),
-                make_cf_log_line(c_ip="203.0.113.1", uri_stem="/cv"),
-            ]
-        )
-        upload_cf_log(s3, log_key, log_content)
-        event = make_s3_event(BUCKET_NAME, log_key)
-
-        with (
-            patch("log_enricher.handler.get_geoip_reader", return_value=mock_geoip_reader),
-            patch("log_enricher.handler.reverse_dns", return_value="host-1.barclays.co.uk"),
-            patch("log_enricher.handler.publish_alert") as mock_publish,
-        ):
-            from log_enricher.handler import handler
-
-            handler(event, None)
-
-        alert = mock_publish.call_args_list[0][0][0]
-        assert "/projects" in alert.message
-        assert "/cv" in alert.message
-        assert "barclays.co.uk" in alert.message
-        assert "linkedin.com" in alert.message
+        assert "alerts/city_cluster/2026-04-14/london.sent" in keys


### PR DESCRIPTION
## Summary
- CF Function now 403s scanner paths (`/xmlrpc.php`, `/.git/*`, `/wp-*`, URL-injection stems, `//` prefix) and scanner UAs (curl/wget/python-requests/masscan/nikto/nuclei/etc.) at the edge — dashboard no longer polluted by scanner noise
- Log-enricher also drops bots, scanner paths, and non-GET/HEAD methods before writing to `enriched/` — double-layer filter
- Removed deep-browse alert: was false-positive on SPA (CloudFront 404→200 fallback makes every URL log as a distinct path, so single-page visitors always triggered "N pages visited")
- S3 `enriched/` retention 90d → 14d; dashboard window 30d → 14d to match

## Test plan
- [ ] `cd terraform/environmental/lambdas/log-enricher && uv run pytest` — 17 passed
- [ ] `cd terraform/environmental/lambdas/dashboard-generator && uv run pytest` — 13 passed
- [ ] `pnpm typecheck` clean
- [ ] `pnpm build` clean
- [ ] `terraform fmt -recursive terraform/` clean
- [ ] Post-deploy: `curl -I https://<domain>/xmlrpc.php` → 403; `curl -I https://<domain>/` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)